### PR TITLE
✨ Allow #embed file replacement and preserve eol-tokens

### DIFF
--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -318,20 +318,20 @@ export class CompilerService {
     }
 
     public async expandToFiles(source: string): Promise<SourceAndFiles> {
-        const includes = new IncludeDownloads();
+        const includesOrEmbeds = new IncludeDownloads();
 
-        const includeFind = /^\s*#\s*include\s*["<](https?:\/\/[^">]+)[">]/;
+        const includeOrEmbedFind = /^\s*#\s*(include|embed)\s*["<](https?:\/\/[^">]+)[">]/;
         const lines = source.split('\n');
         for (const idx in lines) {
             const line = lines[idx];
-            const match = line.match(includeFind);
+            const match = line.match(includeOrEmbedFind);
             if (match) {
-                const download = includes.include(match[1]);
-                lines[idx] = `#include "${download.filename}"`;
+                const download = includesOrEmbeds.include(match[2]);
+                lines[idx] = line.replace(includeOrEmbedFind, `#${match[1]} "${download.filename}"`);
             }
         }
 
-        const files: FiledataPair[] = await includes.allDownloadsAsFileDataPairs();
+        const files: FiledataPair[] = await includesOrEmbeds.allDownloadsAsFileDataPairs();
 
         return {
             source: lines.join('\n'),


### PR DESCRIPTION
Text that comes after the `#embed` (or `#include`) is also now preserved, as in previous times they were ignored (this was allowed by both standards for `#include`, but the tokens that come after `#embed` do matter as they are parameters).